### PR TITLE
reads post text from stdin when no params

### DIFF
--- a/wry/PostCommand.m
+++ b/wry/PostCommand.m
@@ -37,13 +37,19 @@
 }
 
 - (NSString *)usage {
-  return @"<text>";
+  return @"[<text>]\n(omit text to read from stdin)";
 }
 
 - (NSString *)help {
   NSMutableString *help = [[NSMutableString alloc] init];
-  [help appendString:@"Creates a new post with the text you specify. Note that the shell's parsing\n"];
-  [help appendString:@"rules are respected, so escape your text appropriately. Quotes are optional."];
+  [help appendString:
+   @"Creates a new post with the text you specify. If supplying text as command-\n"
+   @"line arguments, note that the shell's parsing rules are respected, so escape\n"
+   @"your text appropriately. Quotes are optional.\n"
+   @"\n"
+   @"Alternatively, supply no arguments and the post body will be read from stdin.\n"
+   @"Enter EOF (^D) to end the post. This lets you avoid all shell quoting, as\n"
+   @"well as create posts by piping input from other commands."];
   return help;
 }
 


### PR DESCRIPTION
[fixes #43]

Example:

``` shell
wry% wry help post
usage: wry post [<text>]
(omit text to read from stdin)

Creates a new post with the text you specify. If supplying text as command-
line arguments, note that the shell's parsing rules are respected, so escape
your text appropriately. Quotes are optional.

Alternatively, supply no arguments and the post body will be read from stdin.
Enter EOF (^D) to end the post. This lets you avoid all shell quoting, as
well as create posts by piping input from other commands.
```

``` shell
wry% wry post 
Testing having wry read post content from stdin.

This is one way out of shell-quote-hell!
Jeremy W. Sherman (@jws) (100550) == You
Testing having wry read post content from stdin.

This is one way out of shell-quote-hell!
ID: 6140932 -- 2013-05-29T03:11:05Z
----------
```

You can read that post to this very day. :)
