### PR TITLE
For links whose text is the same as the URL, don't duplicate.

### DIFF
--- a/wry/ADNLink.m
+++ b/wry/ADNLink.m
@@ -12,7 +12,7 @@
 
 - (NSString *)description {
   if([self.text isEqualToString:self.url]){
-    return [NSString stringWithFormat:@"[%@]", self.text];
+    return [NSString stringWithFormat:@"[%@]", self.url];
   } else {
     return [NSString stringWithFormat:@"[%@](%@)", self.text, self.url];
   }


### PR DESCRIPTION
Visual duplication is a waste of terminal space and is difficult to visually parsing.

(Just trying my hand at Obj-C – sorry if I am violating code style!)

This is just a suggestion for a UI improvement. :)
