### PR TITLE
Use '--' instead of '==' to show following status.

### DIFF
--- a/wry/ADNUser.m
+++ b/wry/ADNUser.m
@@ -13,7 +13,7 @@
 @implementation ADNUser
 
 - (NSString *)shortDescription {
-  return [NSString stringWithFormat:@"%@ (@%@) (%ld) %@==%@ You", self.name, self.username, (long) self.userID,
+  return [NSString stringWithFormat:@"%@ (@%@) (%ld) %@--%@ You", self.name, self.username, (long) self.userID,
                                     (self.youFollow ? @"<" : @""), (self.followsYou ? @">" : @"")];
 }
 


### PR DESCRIPTION
This will minimize the confusion for some naïve compsci folks who equate '==' with 'equals.'

Ambiguity documented here: https://github.com/hoop33/wry/issues/74
